### PR TITLE
Use ~ for $HOME

### DIFF
--- a/StatusbarPath.py
+++ b/StatusbarPath.py
@@ -1,3 +1,5 @@
+import os
+
 import sublime
 import sublime_plugin
 
@@ -9,4 +11,8 @@ class CurrentPathStatusCommand(sublime_plugin.EventListener):
         if filename:
             for folder in view.window().folders():
                 filename = filename.replace(folder, '.')
+
+            if 'HOME' in os.environ:
+                    filename = filename.replace(os.environ['HOME'], '~', 1)
+
             view.set_status('zPath', filename)


### PR DESCRIPTION
Shortens the path by using ~ instead of $HOME.

This was important to me because I often use deep paths and 80col windows. Though subjective, I also feel it enhances readability.

I only tested on OSX, but it probably works in Linux and Windows (though it may or may not make sense in the windows context).
